### PR TITLE
Add hotel brand_Sokos Hotels

### DIFF
--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -4672,6 +4672,18 @@
         "operator:zh": "長榮集團",
         "tourism": "hotel"
       }
+    },
+    {
+      "displayName": "Sokos Hotels",
+      "locationSet": {
+        "include": ["fi", "ee"]
+      },
+      "tags": {
+        "brand": "Sokos Hotels",
+        "brand:wikidata": "Q3915335",
+        "name": "Sokos Hotels",
+        "tourism": "hotel"
+      }
     }
   ]
 }


### PR DESCRIPTION
add missing brand 'Sokos Hotels' for country Finland and Estonia. Sokos Hotels is the most well-known and extensive hotel chain in Finland, comprising nearly 50 hotels across Finland and in Tallinn. As of 2025, Sokos Hotels operates a total of 48 hotels, with 47 located in Finland and 1 in Tallinn, Estonia. Official website: https://www.sokoshotels.fi/en
Q-Code: Q3915335 (Sokos Hotels)