### PR TITLE
Update brand Esprit_DEU

### DIFF
--- a/data/brands/shop/clothes.json
+++ b/data/brands/shop/clothes.json
@@ -3531,7 +3531,10 @@
     {
       "displayName": "Esprit",
       "id": "esprit-3937bd",
-      "locationSet": {"include": ["001"]},
+            "locationSet": {
+        "include": ["001"],
+        "exclude": ["de"]
+      },
       "tags": {
         "brand": "Esprit",
         "brand:wikidata": "Q532746",


### PR DESCRIPTION
exclude country DEU from Esprit brand:
Esprit closed all its remaining physical stores in Germany by the end of January 2025, further information: https://fashionunited.de/nachrichten/einzelhandel/esprit-schliesst-letzte-filialen-in-deutschland/2025013160063 Q-Code: Q532746