### PR TITLE
Update hotel.json add Hotel Anemon

### DIFF
--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -4672,6 +4672,16 @@
         "operator:zh": "長榮集團",
         "tourism": "hotel"
       }
+    },
+    {
+      "displayName": "Anemon Hotel",
+      "locationSet": {"include": ["tr"]},
+      "tags": {
+      "brand": " Anemon Hotel ",
+      "brand:wikidata": " Q111856743",
+      "name": " Anemon Hotel ",
+      "tourism": "hotel"
+      }
     }
   ]
 }


### PR DESCRIPTION
acc to official website Hotel has 25 locations
website: https://anemonhotels.com/our-hotels/?lang=en In Wikidata only Q-codes for single hotels are available and hotel has different types (similar to Hilton group): Anemon Grand, Anemon Kent, Anemon Collectrion, Anemon Siute & Residence. the minimum to be included in the NSI is 30 locations, so this hotel brand is not really a candidate to be added in NSI . Needs to be discussed  - also sitation in Wikidata. Excluded for now