### PR TITLE
Update fast_food.json add brand Etiler Marmaris

### DIFF
--- a/data/brands/amenity/fast_food.json
+++ b/data/brands/amenity/fast_food.json
@@ -13763,6 +13763,18 @@
         "name:zh": "齊柏林熱狗",
         "takeaway": "yes"
       }
+    },
+    {
+      "displayName": "Etiler Marmaris",
+      "locationSet": {"include": ["tr"]},
+      "tags": {
+        "amenity": "fast_food",
+        "brand": " Etiler Marmaris ",
+        "brand:wikidata": "Q136088046",
+       "cuisine": "kebab",
+        "name": " Etiler Marmaris",
+        "takeaway": "yes"
+      }
     }
   ]
 }


### PR DESCRIPTION
new Wikidata entry created (Q136088046)
Etiler Marmaris is a Turkish fast food chain. As of 2025, Etiler Marmaris operates 60 branches across 10 provinces in Turkey.  website: https://etilermarmaris.com.tr/