### PR TITLE
Update hotel.json update countries of brand 'Days Inn'

### DIFF
--- a/data/brands/tourism/hotel.json
+++ b/data/brands/tourism/hotel.json
@@ -967,19 +967,24 @@
       "id": "daysinn-6df761",
       "locationSet": {
         "include": [
+          "ar",
+          "az",
+          "br",
           "ca",
-          "ch",
           "cn",
+          "de",
           "gb",
+          "gu",
           "id",
           "in",
+          "jo",
           "kr",
           "mx",
           "my",
           "ph",
-          "sg",
           "sn",
           "th",
+          "tr",
           "us"
         ]
       },


### PR DESCRIPTION
according to official website:  https://www.wyndhamhotels.com/en-uk/days-inn/locations Brazil, Argentina, Jordan, Turkiye, Germany, Azerbaijan, Guam are missing in NSI and 'ch' (Switzerland) and 'sg' (Singapore) are superfluous (no Days Inn Hotels in these 2 countries) and need to be removed.